### PR TITLE
Update README, dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ will need the following prerequisites:
    reproducible version of Python 3.7.4, which will be used by this project. It
    must be built with the relevant OpenSSL libraries installed.
 2. Install [Bazel](https://bazel.build) (we have tested on a variety of
-   versions, including 3.4.1).
+   versions, including 4.0.0).
 3. Install [Gurobi](https://www.gurobi.com) (we tested 9.0.1 and 9.0.2)
 5. If you want to patch the ImageNet model, see `ImageNet` below.
 6. In another session, clone [SyReNN](https://github.com/95616ARG/SyReNN) and

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy==1.5.2
 # END
 numpy==1.17.2
 imageio==2.5.0
-Pillow==7.1.0
+Pillow==8.2.0
 # For building the package.
 setuptools==41.2.0
 wheel==0.33.6


### PR DESCRIPTION
The README referred to an old Bazel version, and now fixed a buggy dependency (found by Github).